### PR TITLE
initSlider autoplay fix

### DIFF
--- a/sections/sections.js
+++ b/sections/sections.js
@@ -567,8 +567,8 @@ function initSwiper(onlyNew = false) {
 			}
 			params[i] = param;
 		}
-		swiper.push(new Swiper(el, params))
-		//swiper.push(new Swiper(el, { ...{autoplay:{delay: 500}}, ...el.dataset}))		
+		if(params.autoplay == 'true')params.autoplay = {'delay':params.delay};
+		swiper.push(new Swiper(el, params))		
 	});
 }	
 


### PR DESCRIPTION
I do wonder if initSlider func shouldnt be inline js injected into the page content, as once inserted it can update when the repo updates, and the func should be moved to a js file, similarly because the slider css is inserted mid body, its after the head where the editor.style.bundle.css so its harder to override